### PR TITLE
Make this repo an npm web module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
-  "name": "stickyfill",
+  "name": "stickyfill-web-module",
   "version": "1.1.10",
   "license": "MIT",
-  "homepage": "https://github.com/wilddeer/stickyfill",
+  "homepage": "https://github.com/18F/stickyfill",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wilddeer/stickyfill.git"
+    "url": "https://github.com/18F/stickyfill.git"
   },
   "author": {
-    "name": "Oleg Korsunsky",
-    "url": "http://wd.dizaina.net/"
+    "name": "Brian Hedberg"
   },
   "tags": [
     "polyfill",


### PR DESCRIPTION
I updated the package.json to allow me to deploy an npm web module. Take a look at the latest version, [1.1.10](https://www.npmjs.com/package/stickyfill-web-module)